### PR TITLE
feat: modify replies seeder & add reply, like, following and follower…

### DIFF
--- a/controllers/apis/user-controller.js
+++ b/controllers/apis/user-controller.js
@@ -12,6 +12,18 @@ const userController = {
   },
   getTweetsOfUser: (req, res, next) => {
     userService.getTweetsOfUser(req, (err, data) => err ? next(err) : res.status(200).json(data))
+  },
+  getRepliesOfUser: (req, res, next) => {
+    userService.getRepliesOfUser(req, (err, data) => err ? next(err) : res.json(data))
+  },
+  getLikesOfUser: (req, res, next) => {
+    userService.getLikesOfUser(req, (err, data) => err ? next(err) : res.json(data))
+  },
+  getFollowingsOfUser: (req, res, next) => {
+    userService.getFollowingsOfUser(req, (err, data) => err ? next(err) : res.json(data))
+  },
+  getFollowersOfUser: (req, res, next) => {
+    userService.getFollowersOfUser(req, (err, data) => err ? next(err) : res.json(data))
   }
 }
 

--- a/routes/apis/modules/users.js
+++ b/routes/apis/modules/users.js
@@ -2,6 +2,10 @@ const express = require('express')
 const router = express.Router()
 const userController = require('../../../controllers/apis/user-controller')
 
+router.get('/:userId/followings', userController.getFollowingsOfUser)
+router.get('/:userId/replied_tweets', userController.getRepliesOfUser)
+router.get('/:userId/followers', userController.getFollowersOfUser)
+router.get('/:userId/likes', userController.getLikesOfUser)
 router.get('/:userId/tweets', userController.getTweetsOfUser)
 router.get('/:userId', userController.getUser)
 

--- a/seeders/20230321034614-replies-seed-file.js
+++ b/seeders/20230321034614-replies-seed-file.js
@@ -19,8 +19,8 @@ module.exports = {
         User_id: users[Math.floor(Math.random() * users.length)].id,
         Tweet_id: tweets[Math.floor(index / commentsPerTweet)].id, // 使每篇Tweet有三個留言
         comment: faker.lorem.sentence().substring(0, 140),
-        created_at: new Date(),
-        updated_at: new Date()
+        created_at: faker.date.between('2023-02-21T00:00:00.000Z', '2023-02-22T00:00:00.000Z'),
+        updated_at: faker.date.between('2023-02-23T00:00:00.000Z', '2023-02-24T00:00:00.000Z')
       }))
     )
   },


### PR DESCRIPTION
修改 replies seeder以符合時間排序邏輯，加入四隻User相關API（取得所有回覆，所有喜歡的推文，追蹤清單以及追蹤者清單），且均通過Postman測試以及測試檔，Response也有符合Acceptance criteria裏面前端所需的格式